### PR TITLE
Update Trivy installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM alpine:3.21 AS SBOM
 WORKDIR /
 ADD . /SBOM
 RUN apk add --no-cache curl
-RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.68.2
+RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 RUN trivy fs \
   --db-repository public.ecr.aws/aquasecurity/trivy-db \
   --java-db-repository public.ecr.aws/aquasecurity/trivy-java-db \


### PR DESCRIPTION
Removed version specification for Trivy installation.

see https://github.com/kaleido-io/kaleido-planning/issues/6681

https://github.com/kaleido-io/firefly-enterprise/actions/runs/22848789122