### PR TITLE
chore: Ignore GO-2026-5932

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,4 @@
 # not relevant to the way grpc is used in fabconnect
 # see https://github.com/hyperledger/firefly-fabconnect/pull/123#discussion_r1543748524
 GHSA-m425-mq94-257g
+GO-2026-5932


### PR DESCRIPTION
No "fix" is available, and this vuln is really just an deprecation notice.